### PR TITLE
KB721: Replace Ably

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,4 @@
+from setuptools import setup
+
+
+setup()


### PR DESCRIPTION
There are two things that `daphne` doesn't support that we require, which `gunicorn` did.

1. `heroku-nginx-buildpack` expects a file at `/tmp/app-initialized` to exist once the server starts up. We achieved this in Gunicorn via passing in `--config config/gunicorn_config_heroku.py`. Daphne does support a `ready_callable` which is _perfect_ for this kind of thing - but it doesn't actually expose any way for us to define it!! https://github.com/AccessIQ/daphne/commit/91565d014b2dc06f1032780029ce456ef19daffd
2. Daphne runs out of `/app/` on Heroku, but we require it to be running from `/app/django-root/`. Gunicorn allows us to specify `chdir` within our `config/gunicorn_config_heroku.py` file to achieve this - unfortunately Daphne isn't designed for this whatsoever. Even changing the launch command to `cd django-root && ...` doesn't work as then everything else starts to break. I investigated _many_ options here - the only solution that works 100% is in this PR - cd into django-root, import our ASGI application, then cd back out. https://github.com/AccessIQ/daphne/commit/7ef8d12e3c4608186e6edf110f64a5ae12ad2a8c

Daphne also decided to migrate `setup.py` to `setup.cfg` in Dec 2022: https://github.com/django/daphne/commit/d59c2bd4242f81206f5aaa04832d7aba898b4cd6
This caused Alliance's CI to fail. I've just instated a shortcut in a new `setup.py` to run setuptools directly, which then uses the config in `setup.cfg`.